### PR TITLE
feat: add `CurveAffineExt` trait with `into_coordinates`

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -70,3 +70,12 @@ pub(crate) fn mul_512(a: [u64; 4], b: [u64; 4]) -> [u64; 8] {
 
     [r0, r1, r2, r3, r4, r5, r6, carry_out]
 }
+
+pub trait CurveAffineExt: pasta_curves::arithmetic::CurveAffine {
+    /// Unlike the `Coordinates` trait, this just returns the raw affine coordinates without checking `is_on_curve`
+    fn into_coordinates(self) -> (Self::Base, Self::Base) {
+        // fallback implementation
+        let coordinates = self.coordinates().unwrap();
+        (*coordinates.x(), *coordinates.y())
+    }
+}

--- a/src/bn256/curve.rs
+++ b/src/bn256/curve.rs
@@ -1,7 +1,7 @@
 use crate::arithmetic::mul_512;
 use crate::arithmetic::sbb;
-use crate::arithmetic::CurveEndo;
 use crate::arithmetic::EndoParameters;
+use crate::arithmetic::{CurveAffineExt, CurveEndo};
 use crate::bn256::Fq;
 use crate::bn256::Fq2;
 use crate::bn256::Fr;

--- a/src/derive/curve.rs
+++ b/src/derive/curve.rs
@@ -848,6 +848,11 @@ macro_rules! new_curve_impl {
             }
         }
 
+        impl CurveAffineExt for $name_affine {
+            fn into_coordinates(self) -> (Self::Base, Self::Base) {
+                (self.x, self.y)
+            }
+        }
 
         impl_binops_additive!($name, $name);
         impl_binops_additive!($name, $name_affine);

--- a/src/grumpkin/curve.rs
+++ b/src/grumpkin/curve.rs
@@ -1,7 +1,7 @@
 use crate::arithmetic::mul_512;
 use crate::arithmetic::sbb;
-use crate::arithmetic::CurveEndo;
 use crate::arithmetic::EndoParameters;
+use crate::arithmetic::{CurveAffineExt, CurveEndo};
 use crate::ff::WithSmallOrderMulGroup;
 use crate::ff::{Field, PrimeField};
 use crate::group::Curve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod secq256k1;
 
 #[macro_use]
 mod derive;
+pub use arithmetic::CurveAffineExt;
 pub use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
 // Re-export ff and group to simplify down stream dependencies

--- a/src/secp256k1/curve.rs
+++ b/src/secp256k1/curve.rs
@@ -4,7 +4,7 @@ use crate::group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
 use crate::hash_to_curve::svdw_hash_to_curve;
 use crate::secp256k1::Fp;
 use crate::secp256k1::Fq;
-use crate::{Coordinates, CurveAffine, CurveExt};
+use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt};
 use core::cmp;
 use core::fmt::Debug;
 use core::iter::Sum;

--- a/src/secp256r1/curve.rs
+++ b/src/secp256r1/curve.rs
@@ -3,7 +3,7 @@ use crate::ff::{Field, PrimeField};
 use crate::group::{prime::PrimeCurveAffine, Curve, Group as _, GroupEncoding};
 use crate::secp256r1::Fp;
 use crate::secp256r1::Fq;
-use crate::{Coordinates, CurveAffine, CurveExt};
+use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt};
 use core::cmp;
 use core::fmt::Debug;
 use core::iter::Sum;

--- a/src/secq256k1/curve.rs
+++ b/src/secq256k1/curve.rs
@@ -9,7 +9,7 @@ use crate::{
     impl_binops_multiplicative, impl_binops_multiplicative_mixed, impl_sub_binop_specify_output,
     new_curve_impl,
 };
-use crate::{Coordinates, CurveAffine, CurveExt};
+use crate::{Coordinates, CurveAffine, CurveAffineExt, CurveExt};
 use core::cmp;
 use core::fmt::Debug;
 use core::iter::Sum;


### PR DESCRIPTION
Direct conversion of affine curve into coordinates without checking `is_on_curve`.