### PR TITLE
Implement bls12_381 assembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,11 @@ rayon = "1.8"
 digest = "0.10.7"
 sha2 = "0.10.8"
 unroll = "0.1.5"
+blst = { version = "0.3", optional = true }
 
 [features]
 default = ["bits", "bn256-table", "derive_serde"]
-asm = []
+asm = ["blst"]
 bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]

--- a/src/bls12_381/assembly.rs
+++ b/src/bls12_381/assembly.rs
@@ -1,0 +1,63 @@
+#![cfg(all(feature = "asm", target_arch = "x86_64"))]
+
+use blst::{blst_fp, blst_fp_add, blst_fp_cneg, blst_fp_mul, blst_fp_sqr, blst_fp_sub};
+
+use super::fp::Fp;
+
+#[inline(always)]
+fn fp_as_blst(fp: &Fp) -> *const blst_fp {
+    fp as *const Fp as *const blst_fp
+}
+
+#[inline(always)]
+fn fp_as_mut_blst(fp: &mut Fp) -> *mut blst_fp {
+    fp as *mut Fp as *mut blst_fp
+}
+
+impl Fp {
+    #[inline]
+    pub fn add(&self, rhs: &Fp) -> Fp {
+        let mut out = Fp::zero();
+        unsafe {
+            blst_fp_add(fp_as_mut_blst(&mut out), fp_as_blst(self), fp_as_blst(rhs));
+        }
+        out
+    }
+
+    #[inline]
+    pub fn sub(&self, rhs: &Fp) -> Fp {
+        let mut out = Fp::zero();
+        unsafe {
+            blst_fp_sub(fp_as_mut_blst(&mut out), fp_as_blst(self), fp_as_blst(rhs));
+        }
+        out
+    }
+
+    #[inline]
+    pub fn neg(&self) -> Fp {
+        let mut out = Fp::zero();
+        unsafe {
+            // cneg computes (-a) when flag == true and leaves it unchanged otherwise.
+            blst_fp_cneg(fp_as_mut_blst(&mut out), fp_as_blst(self), true);
+        }
+        out
+    }
+
+    #[inline]
+    pub fn mul(&self, rhs: &Fp) -> Fp {
+        let mut out = Fp::zero();
+        unsafe {
+            blst_fp_mul(fp_as_mut_blst(&mut out), fp_as_blst(self), fp_as_blst(rhs));
+        }
+        out
+    }
+
+    #[inline]
+    pub fn square(&self) -> Fp {
+        let mut out = Fp::zero();
+        unsafe {
+            blst_fp_sqr(fp_as_mut_blst(&mut out), fp_as_blst(self));
+        }
+        out
+    }
+}

--- a/src/bls12_381/fp.rs
+++ b/src/bls12_381/fp.rs
@@ -20,6 +20,7 @@ use crate::{
 /// The internal representation of this type is six 64-bit unsigned
 /// integers in little-endian order. `Fp` values are always in
 /// Montgomery form; i.e., Scalar(a) = aR mod p, with R = 2^384.
+#[repr(transparent)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Fp(pub(crate) [u64; 6]);
 
@@ -666,6 +667,7 @@ impl Fp {
         Fp([r0, r1, r2, r3, r4, r5])
     }
 
+    #[cfg(not(feature = "asm"))]
     #[inline]
     /// Performs constant time addition of two elements.
     pub const fn add(&self, rhs: &Fp) -> Fp {
@@ -681,6 +683,7 @@ impl Fp {
         (Fp([d0, d1, d2, d3, d4, d5])).subtract_p()
     }
 
+    #[cfg(not(feature = "asm"))]
     #[inline]
     /// Performs constant time negation of an element.
     pub const fn neg(&self) -> Fp {
@@ -707,6 +710,7 @@ impl Fp {
         ])
     }
 
+    #[cfg(not(feature = "asm"))]
     #[inline]
     /// Performs constant time subtraction of two elements.
     pub const fn sub(&self, rhs: &Fp) -> Fp {
@@ -852,6 +856,7 @@ impl Fp {
         (&Fp([r6, r7, r8, r9, r10, r11])).subtract_p()
     }
 
+    #[cfg(not(feature = "asm"))]
     #[inline]
     /// Performs constant time multiplication of two elements.
     pub const fn mul(&self, rhs: &Fp) -> Fp {
@@ -901,6 +906,7 @@ impl Fp {
     }
 
     /// Squares this element.
+    #[cfg(not(feature = "asm"))]
     #[inline]
     pub const fn square(&self) -> Self {
         let (t1, carry) = mac(0, self.0[0], self.0[1], 0);

--- a/src/bls12_381/mod.rs
+++ b/src/bls12_381/mod.rs
@@ -29,6 +29,8 @@ pub use scalar::Scalar as Fr;
 use scalar::Scalar;
 
 mod fp;
+#[cfg(all(feature = "asm", target_arch = "x86_64"))]
+mod assembly;
 mod fp2;
 mod g1;
 mod g2;


### PR DESCRIPTION
Add BLST assembly optimizations for `bls12_381`'s `Fp` field arithmetic to improve performance.

The `Fp` struct is marked `#[repr(transparent)]` to allow safe reinterpretation as `blst_fp`, enabling the use of Supranational's optimized BLST assembly functions for `add`, `sub`, `neg`, `mul`, and `square` when the `asm` feature is enabled. This parallels the existing assembly acceleration for `bn256`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a26f3aae-60d3-47e4-bd35-c057887fb036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a26f3aae-60d3-47e4-bd35-c057887fb036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

