### PR TITLE
Implement bls12_381 assembly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,11 @@ rayon = "1.8"
 digest = "0.10.7"
 sha2 = "0.10.8"
 unroll = "0.1.5"
+blst = { version = "0.3.11", optional = true }
 
 [features]
 default = ["bits", "bn256-table", "derive_serde"]
-asm = []
+asm = ["blst"]
 bits = ["ff/bits"]
 bn256-table = []
 derive_serde = ["serde/derive", "serde_arrays", "hex"]

--- a/src/bls12_381/fp/assembly.rs
+++ b/src/bls12_381/fp/assembly.rs
@@ -1,0 +1,67 @@
+use blst::{blst_fp, blst_fp_add, blst_fp_mul, blst_fp_sqr, blst_fp_sub};
+
+use super::Fp;
+
+#[inline(always)]
+fn to_blst_fp(value: &Fp) -> blst_fp {
+    blst_fp { l: value.0 }
+}
+
+#[inline(always)]
+fn from_blst_fp(value: &blst_fp) -> Fp {
+    Fp(value.l)
+}
+
+#[inline(always)]
+pub(super) fn add(lhs: &Fp, rhs: &Fp) -> Fp {
+    let a = to_blst_fp(lhs);
+    let b = to_blst_fp(rhs);
+    let mut out = blst_fp { l: [0; 6] };
+    unsafe {
+        blst_fp_add(&mut out, &a, &b);
+    }
+    from_blst_fp(&out)
+}
+
+#[inline(always)]
+pub(super) fn sub(lhs: &Fp, rhs: &Fp) -> Fp {
+    let a = to_blst_fp(lhs);
+    let b = to_blst_fp(rhs);
+    let mut out = blst_fp { l: [0; 6] };
+    unsafe {
+        blst_fp_sub(&mut out, &a, &b);
+    }
+    from_blst_fp(&out)
+}
+
+#[inline(always)]
+pub(super) fn neg(value: &Fp) -> Fp {
+    let zero = blst_fp { l: [0; 6] };
+    let a = to_blst_fp(value);
+    let mut out = blst_fp { l: [0; 6] };
+    unsafe {
+        blst_fp_sub(&mut out, &zero, &a);
+    }
+    from_blst_fp(&out)
+}
+
+#[inline(always)]
+pub(super) fn mul(lhs: &Fp, rhs: &Fp) -> Fp {
+    let a = to_blst_fp(lhs);
+    let b = to_blst_fp(rhs);
+    let mut out = blst_fp { l: [0; 6] };
+    unsafe {
+        blst_fp_mul(&mut out, &a, &b);
+    }
+    from_blst_fp(&out)
+}
+
+#[inline(always)]
+pub(super) fn square(value: &Fp) -> Fp {
+    let a = to_blst_fp(value);
+    let mut out = blst_fp { l: [0; 6] };
+    unsafe {
+        blst_fp_sqr(&mut out, &a);
+    }
+    from_blst_fp(&out)
+}


### PR DESCRIPTION
Integrate BLST's hand-optimized assembly for BLS12-381 field arithmetic to improve performance.

---
<a href="https://cursor.com/background-agent?bcId=bc-39feabed-e90e-4b3c-bafc-704e84ffbfd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39feabed-e90e-4b3c-bafc-704e84ffbfd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

