### PR TITLE
fix(asm): remove nostack

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves-axiom"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Privacy Scaling Explorations team",
     "Taiko Labs",

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -56,7 +56,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") r1,
                         out("r14") r2,
                         out("r15") r3,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     );
                 }
                 $field([r0, r1, r2, r3])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `nostack` option from the bn256 assembly `double` routine and bumps crate version to 0.7.1.
> 
> - **Assembly (bn256)**:
>   - Remove `nostack` from `options(pure, readonly)` in `src/bn256/assembly.rs` for the `double` operation.
> - **Crate**:
>   - Bump `Cargo.toml` version to `0.7.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41a6a1eea9c432ffdec42f3c7e433606b9d210f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->