### PR TITLE
fix: remove `nostack` completely

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2curves-axiom"
-version = "0.7.1"
+version = "0.7.2"
 authors = [
     "Privacy Scaling Explorations team",
     "Taiko Labs",

--- a/src/bn256/assembly.rs
+++ b/src/bn256/assembly.rs
@@ -193,7 +193,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") _,
                         out("r14") _,
                         out("r15") _,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     )
                 }
                 $field([r0, r1, r2, r3])
@@ -431,7 +431,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") r1,
                         out("r14") r3,
                         out("r15") _,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     )
                 }
 
@@ -492,7 +492,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") r1,
                         out("r14") r2,
                         out("r15") r3,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     );
                 }
                 $field([r0, r1, r2, r3])
@@ -548,7 +548,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") r1,
                         out("r14") r2,
                         out("r15") r3,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     );
                 }
                 $field([r0, r1, r2, r3])
@@ -602,7 +602,7 @@ macro_rules! field_arithmetic_asm {
                         out("r13") _,
                         out("r14") _,
                         out("r15") _,
-                        options(pure, readonly, nostack)
+                        options(pure, readonly)
                     )
                 }
                 $field([r0, r1, r2, r3])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes the `nostack` option from BN256 inline assembly and bumps the crate version to 0.7.2.
> 
> - **BN256 assembly (`src/bn256/assembly.rs`)**:
>   - Remove `nostack` from inline `asm!` options across field ops (`double`, `montgomery_reduce_256`, `mul`, `sub`, `add`, `neg`).
> - **Cargo**:
>   - Bump `version` to `0.7.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5b383a5d50439a3f293eab28338a22875b2fa9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->