### PR TITLE
perf: wrap blstrs implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ rayon = "1.8"
 digest = "0.10.7"
 sha2 = "0.10.8"
 unroll = "0.1.5"
+blstrs = {version = "0.7", features = ["__private_bench"] } 
 
 [features]
 default = ["bits", "bn256-table", "derive_serde"]

--- a/src/bls12_381/fp.rs
+++ b/src/bls12_381/fp.rs
@@ -641,7 +641,7 @@ impl Fp {
 
         let blstrs_fp: BlstrsFp = BlstrsFp::from_bytes_le(&bytes).unwrap();
 
-        let inverted: BlstrsFp  = blstrs_fp.invert().unwrap();
+        let inverted: BlstrsFp = blstrs_fp.invert().unwrap();
         let inverted_bytes = inverted.to_bytes_le();
 
         Self::from_bytes(&inverted_bytes)

--- a/src/bls12_381/fp.rs
+++ b/src/bls12_381/fp.rs
@@ -632,17 +632,19 @@ impl Fp {
     /// element, returning None in the case that this element
     /// is zero.
     pub fn invert(&self) -> CtOption<Self> {
-        // Exponentiate by p - 2
-        let t = self.pow_vartime(&[
-            0xb9fe_ffff_ffff_aaa9,
-            0x1eab_fffe_b153_ffff,
-            0x6730_d2a0_f6b0_f624,
-            0x6477_4b84_f385_12bf,
-            0x4b1b_a7b6_434b_acd7,
-            0x1a01_11ea_397f_e69a,
-        ]);
+        use blstrs::Fp as BlstrsFp;
 
-        CtOption::new(t, !self.is_zero())
+        let bytes = self.to_bytes();
+        if bool::from(self.is_zero()) {
+            return CtOption::new(Fp::zero(), !self.is_zero());
+        }
+
+        let blstrs_fp: BlstrsFp = BlstrsFp::from_bytes_le(&bytes).unwrap();
+
+        let inverted: BlstrsFp  = blstrs_fp.invert().unwrap();
+        let inverted_bytes = inverted.to_bytes_le();
+
+        Self::from_bytes(&inverted_bytes)
     }
 
     #[inline]


### PR DESCRIPTION
Closes INT-5525

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates `blstrs` and replaces `Fp::invert` with a `blstrs`-backed implementation via transparent conversions.
> 
> - **BLS12-381 `Fp`**:
>   - Add `#[repr(transparent)]` to `Fp` and unsafe helpers to convert to/from `blstrs::Fp`.
>   - Replace exponentiation-based inversion with `blstrs`-backed `invert`, with explicit zero handling.
> - **Dependencies**:
>   - Add `blstrs = "0.7"` (with `__private_bench` feature) in `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 175e7c0cd818c436570f62c30fb01295ea287232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->